### PR TITLE
Uses RNN hidden state instead of output states

### DIFF
--- a/multifew/main.py
+++ b/multifew/main.py
@@ -143,7 +143,7 @@ def parse_args():
 
     args.device = torch.device("cuda") if (not args.disable_cuda) and \
         torch.cuda.is_available() else torch.device("cpu")
-    print(f"running on device {torch.cuda.current_device()}")
+    print(f"running on device {args.device}")
 
     return args
 

--- a/multifew/models/am3.py
+++ b/multifew/models/am3.py
@@ -10,7 +10,7 @@ from tqdm.autonotebook import tqdm
 
 from utils.average_meter import AverageMeter
 from utils import utils as utils
-from .common import WordEmbedding, RNN
+from .common import WordEmbedding, RNN, RnnHid
 
 
 class AM3(nn.Module):
@@ -60,6 +60,9 @@ class AM3(nn.Module):
         elif self.text_encoder_type == "RNN":
             # TODO optional embedding type
             self.text_encoder = RNN("glove", self.pooling_strat,
+                                    self.dictionary, self.text_emb_dim)
+        elif self.text_encoder_type == "RNNhid":
+            self.text_encoder = RnnHid("glove", self.pooling_strat,
                                     self.dictionary, self.text_emb_dim)
         elif self.text_encoder_type == "rand":
             self.text_encoder = nn.Linear(self.text_emb_dim, self.text_emb_dim)

--- a/multifew/models/common.py
+++ b/multifew/models/common.py
@@ -152,8 +152,7 @@ class RnnHid(nn.Module):
         
         # feed through RNN
         text_embedding_packed = pack_padded_sequence(text_embedding, seq_lens, batch_first=True, enforce_sorted=False)
-        rnn_out_packed, _ = self.rnn(text_embedding_packed)
-        _, (ht, _) = pad_packed_sequence(rnn_out_packed, batch_first=True)     # (B*N*K, max_seq_len, rnn_hid_dim*2)
+        _, (ht, _) = self.rnn(text_embedding_packed)
 
         # concat forward and backward results (takes hidden states)
         seq_embed = torch.cat((ht[0], ht[1]), dim=-1)

--- a/multifew/models/common.py
+++ b/multifew/models/common.py
@@ -109,7 +109,7 @@ class RnnHid(nn.Module):
     def __init__(self, embedding_type, pooling_strat, dictionary, rnn_hid_dim):
         """Embeds tokenised sequence into a fixed length encoding with an RNN.
         """
-        super(RNN, self).__init__()
+        super(RnnHid, self).__init__()
         self.pooling_strat = pooling_strat
         self.dictionary = dictionary
         self.embedding_type = embedding_type

--- a/multifew/models/common.py
+++ b/multifew/models/common.py
@@ -101,6 +101,95 @@ class RNN(nn.Module):
         return seq_embed.view(B, NK, -1)        # (B, N*K, rnn_hid_dim*2)
 
 
+class RnnHid(nn.Module):
+    """RNN model in Pytorch for classification
+    Using hidden state as features (not outputs)
+    """
+
+    def __init__(self, embedding_type, pooling_strat, dictionary, rnn_hid_dim):
+        """Embeds tokenised sequence into a fixed length encoding with an RNN.
+        """
+        super(RNN, self).__init__()
+        self.pooling_strat = pooling_strat
+        self.dictionary = dictionary
+        self.embedding_type = embedding_type
+        self.rnn_hid_dim = rnn_hid_dim // 2      # assuming bidirectional
+        self.padding_token = self.dictionary["PAD"]
+
+        # word embedding
+        if embedding_type == "rand":
+            self.embed = nn.Embedding(len(self.dictionary), rnn_hid_dim)
+            self.text_emb_size = rnn_hid_dim
+        else:
+            embedding_weights = get_embedding_weights(dictionary, embedding_type)
+            self.text_emb_size = embedding_weights.shape[-1]
+            self.embed = nn.Embedding.from_pretrained(torch.FloatTensor(embedding_weights))
+
+        # RNN 
+        self.rnn = nn.LSTM(
+            input_size=self.text_emb_size,
+            hidden_size=self.rnn_hid_dim,
+            num_layers=1,
+            bidirectional=True,
+            batch_first=True)
+
+    def forward(self, x):
+        """Params:
+        - x (torch.LongTensor): tokenised sequence (b x N*K x max_seq_len)
+        Returns:
+        - text_embedding (torch.FloatTensor): embedded sequence (b x N*K x emb_dim)
+        """
+        # process data
+        B, NK, max_seq_len = x.shape
+        # flatten batch
+        x_flat = x.view(-1, max_seq_len)    # (B*N*K x max_seq_len)
+        # padding_masks
+        padding_mask = torch.where(x_flat != self.padding_token, 1, 0)
+        seq_lens = torch.sum(padding_mask, dim=-1).cpu()      # (B*N*K)
+
+        # embed
+        text_embedding = self.embed(x_flat)      # (B*N*K x max_seq_len x emb_dim)
+        
+        # feed through RNN
+        text_embedding_packed = pack_padded_sequence(text_embedding, seq_lens, batch_first=True, enforce_sorted=False)
+        rnn_out_packed, _ = self.rnn(text_embedding_packed)
+        _, (ht, _) = pad_packed_sequence(rnn_out_packed, batch_first=True)     # (B*N*K, max_seq_len, rnn_hid_dim*2)
+
+        # concat forward and backward results (takes hidden states)
+        seq_embed = torch.cat((ht[0], ht[1]), dim=-1)
+        # unsqueeze
+        return seq_embed.view(B, NK, -1)        # (B, N*K, rnn_hid_dim*2)
+
+    def forward(self, x, feats=False):
+        """Params:
+        - x (dict): dict of input tensors
+        - feats (bool): whether to return text embedding
+        """
+        text = x["input_ids"]
+        B, _ = text.shape
+        # padding masks (padding token = 0)
+        padding_mask = torch.where(text != 0, 1, 0)
+        seq_lens = torch.sum(padding_mask, dim=-1).cpu()
+
+        # embed
+        text_embedding = self.embed(text)      # (B x max_seq_len x emb_dim)
+
+        # feed through RNN
+        text_embedding_packed = pack_padded_sequence(text_embedding, seq_lens, batch_first=True, enforce_sorted=False)
+        self.rnn.flatten_parameters()   # to prevent baal error
+        _, (ht, _) = self.rnn(text_embedding_packed)
+
+        # concat forward and backward results (takes hidden states)
+        seq_embed = torch.cat((ht[0], ht[1]), dim=-1)
+        # classify        
+        logits = self.classifier(self.dropout(seq_embed))
+
+        if feats:
+            return logits, seq_embed
+        else:
+            return logits
+
+
 def get_embedding_weights(dictionary, text_encoder_type):
     """Loads gensim word embedding weights into a matrix
     Params:

--- a/multifew/models/fumi.py
+++ b/multifew/models/fumi.py
@@ -11,7 +11,7 @@ from torchmeta.utils.gradient_based import gradient_update_parameters
 
 from utils.average_meter import AverageMeter
 from utils import utils as utils
-from .common import WordEmbedding
+from .common import WordEmbedding, RnnHid, RNN
 
 
 class FUMI(nn.Module):
@@ -30,7 +30,7 @@ class FUMI(nn.Module):
         self.im_emb_dim = im_emb_dim
         self.im_hid_dim = im_hid_dim
         self.text_encoder_type = text_encoder
-        self.text_emb_dim = text_emb_dim  # only applicable if precomputed
+        self.text_emb_dim = text_emb_dim  # only applicable if precomputed or RNN hid dim
         self.text_hid_dim = text_hid_dim
         self.dictionary = dictionary  # for word embeddings
         self.pooling_strat = pooling_strat
@@ -48,6 +48,10 @@ class FUMI(nn.Module):
             self.text_emb_dim = self.text_encoder.embedding_dim
         elif self.text_encoder_type == "rand":
             self.text_encoder = nn.Linear(self.text_emb_dim, self.text_emb_dim)
+        elif self.text_encoder_type == "RNN":
+            self.text_encoder = RNN("glove", self.pooling_strat, self.dictionary, self.text_emb_dim)
+        elif self.text_encoder_type == "RNNhid":
+            self.text_encoder = RnnHid("glove", self.pooling_strat, self.dictionary, self.text_emb_dim)
         else:
             raise NameError(f"{text_encoder} not allowed as text encoder")
 

--- a/multifew/utils/utils.py
+++ b/multifew/utils/utils.py
@@ -125,8 +125,9 @@ def parser():
     parser.add_argument(
         "--text_encoder",
         type=str,
+        choices=['glove', 'w2v', 'RNN', 'RNNhid', 'BERT', 'rand'],
         default="BERT",
-        help="Type of text embedding (glove, w2v, RNN, BERT, rand)")
+        help="Type of text embedding (glove, w2v, RNN, RNNhid, BERT, rand)")
     parser.add_argument(
         "--pooling_strat",
         type=str,


### PR DESCRIPTION
Use `--text-encoder RNNhid` in command line arguments to use the hidden state RNN instead.